### PR TITLE
fix: add required dns packages and ansible tags

### DIFF
--- a/examples/front/playbook.yml
+++ b/examples/front/playbook.yml
@@ -23,5 +23,7 @@
       ansible.builtin.setup:
 
   roles:
-    - batcher
-    - proxy
+    - name: batcher
+      tags: batcher
+    - name: proxy
+      tags: proxy

--- a/examples/front/roles/proxy/tasks/main.yml
+++ b/examples/front/roles/proxy/tasks/main.yml
@@ -6,6 +6,7 @@
       - ca-certificates
       - certbot
       - python3-certbot-nginx
+      - python3-certbot-dns-cloudflare
     cache_valid_time: 86400
 
 - name: Determine certbot validation mode

--- a/examples/front/roles/proxy/tasks/main.yml
+++ b/examples/front/roles/proxy/tasks/main.yml
@@ -6,7 +6,6 @@
       - ca-certificates
       - certbot
       - python3-certbot-nginx
-      - python3-certbot-dns-cloudflare
     cache_valid_time: 86400
 
 - name: Determine certbot validation mode
@@ -37,6 +36,12 @@
 - name: Prepare certifiate with Cloudflare validation
   when: proxy_certbot_validation_mode == "cloudflare"
   block:
+    - name: Install cloudflare dns certbot package
+      ansible.builtin.apt:
+        name:
+          - python3-certbot-dns-cloudflare
+        cache_valid_time: 86400
+
     - name: Copy Cloudflare API credentials
       ansible.builtin.template:
         src: cloudflare.ini.j2


### PR DESCRIPTION
Allows someone to skip the "proxy" or "batcher" roles.